### PR TITLE
Storage simplified interface, removed unused code and others

### DIFF
--- a/broker/pkg/storage/timeline/timeline.go
+++ b/broker/pkg/storage/timeline/timeline.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/dejaq/prototype/broker/domain"
 
-	"github.com/dejaq/prototype/common/errors"
-
 	"github.com/dejaq/prototype/common/timeline"
 )
 
@@ -15,13 +13,14 @@ type MsgTime struct {
 	NewTimestamp uint64
 }
 
-// TODO inconsistent error management, sometimes return error and other times []errors
-// Insert return collection and GetAndLease return only one
+// The representation of a Timeline storage.
+// See the architecture docs on the design principles and for what actions are responsible it has.
 type Repository interface {
-	// Create a sample interface
+	// Returns a Dejaror
 	CreateTopic(ctx context.Context, timelineID string) error
-	// INSERT messages (timelineID, []messages) map[msgID]error
-	Insert(ctx context.Context, timelineID []byte, messages []timeline.Message) []errors.MessageIDTuple
+	// INSERT messages in a timeline
+	// Returns a Dejaror or a MessageIDTupleList (if only specific messages failed)
+	Insert(ctx context.Context, req timeline.InsertMessagesRequest) error
 	// Get messages from storage and apply Lease on them
 	// maxTimeMS -> maximum timestamp for prefetch messages
 	// TODO add structure here
@@ -35,21 +34,12 @@ type Repository interface {
 		currentTimeMS uint64,
 		maxTimeMS uint64,
 	) ([]timeline.Lease, bool, error)
-	// LOOKUP message by TimelineID, MsgID (owner control, lease operations)
-	Lookup(ctx context.Context, timelineID []byte, messageIDs [][]byte) ([]timeline.Message, []errors.MessageIDTuple)
 	// DELETE remove message(s) from storage
 	// Only CONSUMER that have an active lease can delete a message
 	// Only PRODUCER that own message, message is not leased by a CONSUMER can delete it
 	// Lease is implemented at storage level
-	Delete(ctx context.Context, deleteMessages timeline.DeleteMessages) []errors.MessageIDTuple
-	// COUNT messages BY TimelineID, RANGE (spike detection/consumer scaling and metrics)
-	CountByRange(ctx context.Context, timelineID []byte, a, b uint64) uint64
-	// COUNT messages BY TimelineID, RANGE and LockConsumerID is empty (count processing status)
-	CountByRangeProcessing(ctx context.Context, timelineID []byte, a, b uint64) uint64
-	// COUNT messages BY TimelineID, RANGE and LockConsumerID is not empty (count waiting status)
-	CountByRangeWaiting(ctx context.Context, timelineID []byte, a, b uint64) uint64
+	// Returns a Dejaror or a MessageIDTupleList (if only specific messages failed)
+	Delete(ctx context.Context, req timeline.DeleteMessagesRequest) error
 	// SelectByConsumer return consumer associated messages already leased
 	SelectByConsumer(ctx context.Context, timelineID []byte, consumerID []byte, buckets domain.BucketRange, limit int, maxTimestamp uint64) ([]timeline.Lease, bool, error)
-	// SELECT messages by TimelineID, ProducerOwnerID (ownership control)
-	SelectByProducer(ctx context.Context, timelineID []byte, producerID []byte) []timeline.Message
 }

--- a/client/timeline/consumer/consumer.go
+++ b/client/timeline/consumer/consumer.go
@@ -260,7 +260,7 @@ func (c *Consumer) receiveMessages(ctx context.Context, bidiStream dejaq.Broker_
 		c.msgBuffer <- timeline.Lease{
 			ExpirationTimestampMS: response.ExpirationTSMSUTC(),
 			ConsumerID:            response.ConsumerIDBytes(),
-			Message: timeline.LeaseMessage{
+			Message: timeline.MessageLease{
 				ID:              msg.MessageIDBytes(),
 				TimestampMS:     msg.TimestampMS(),
 				ProducerGroupID: msg.ProducerGroupIDBytes(),

--- a/common/timeline/message.go
+++ b/common/timeline/message.go
@@ -1,0 +1,120 @@
+package timeline
+
+import "unsafe"
+
+// Message is a timeline full representation. Not all the fields are populated all the time
+type Message struct {
+	//An UUID, unique across the topic, as string, non-canonical form, without hypes and stored as bytes
+	ID []byte
+	// the Unix timestamp, in milliseconds, when the message should be processed
+	TimestampMS uint64
+	// the id of the payload
+	BodyID []byte
+	// the payload
+	Body []byte
+	// Group of producers that has ownership, string
+	ProducerGroupID []byte
+	// Unique consumer client id that has a lock on it. Only valid if TimestampMS >= Now()
+	LockConsumerID []byte
+	// Randomly chosen at creation, used by the Loader
+	BucketID uint16
+	// Updated at each mutation, used to detect mutation contention
+	Version uint16
+}
+
+func (m Message) GetID() string {
+	return *(*string)(unsafe.Pointer(&m.ID))
+}
+
+func (m Message) GetBodyID() string {
+	return *(*string)(unsafe.Pointer(&m.BodyID))
+}
+
+func (m Message) GetBody() string {
+	return *(*string)(unsafe.Pointer(&m.Body))
+}
+
+func (m Message) GetProducerGroupID() string {
+	return *(*string)(unsafe.Pointer(&m.ProducerGroupID))
+}
+
+func (m Message) GetLockConsumerID() string {
+	return *(*string)(unsafe.Pointer(&m.LockConsumerID))
+}
+
+func (m Message) String() string {
+	return "{Message [id:" + m.GetID() + "]"
+}
+
+type DeleteCaller uint8
+
+const (
+	DeleteCallerConsumer DeleteCaller = iota
+	DeleteCallerProducer
+)
+
+type DeleteMessagesRequest struct {
+	// Reference timestamp for calculate active leases
+	Timestamp uint64
+	// Who wants to delete messages
+	CallerType DeleteCaller
+	//Identity of who wants to delete
+	CallerID   string
+	TimelineID string
+	Messages   []DeleteMessagesRequestItem
+}
+
+func (dm *DeleteMessagesRequest) GetTimelineID() string {
+	return *(*string)(unsafe.Pointer(&dm.TimelineID))
+}
+
+type DeleteMessagesRequestItem struct {
+	MessageID []byte
+	BucketID  uint16
+	Version   uint16
+}
+
+func (r DeleteMessagesRequestItem) GetMessageID() string {
+	return *(*string)(unsafe.Pointer(&r.MessageID))
+}
+
+type InsertMessagesRequest struct {
+	TimelineID string
+	// Group of producers that has ownership, string
+	ProducerGroupID string
+	Messages        []InsertMessagesRequestItem
+}
+
+func (m InsertMessagesRequest) GetProducerGroupID() string {
+	return m.ProducerGroupID
+}
+
+func (m InsertMessagesRequest) GetTimelineID() string {
+	return m.TimelineID
+}
+
+// Message is a timeline full representation. Not all the fields are populated all the time
+type InsertMessagesRequestItem struct {
+	//An UUID, unique across the topic, as string, non-canonical form, without hypes and stored as bytes
+	ID []byte
+	// the Unix timestamp, in milliseconds, when the message should be processed
+	TimestampMS uint64
+	// the payload
+	Body []byte
+	// Randomly chosen at creation, used by the Loader
+	BucketID uint16
+	// Updated at each mutation, used to detect mutation contention
+	Version uint16
+}
+
+func (m InsertMessagesRequestItem) GetID() string {
+	return *(*string)(unsafe.Pointer(&m.ID))
+}
+
+func (m InsertMessagesRequestItem) GetBody() string {
+	return *(*string)(unsafe.Pointer(&m.Body))
+}
+
+func (m InsertMessagesRequestItem) String() string {
+	return "{InsertMessagesRequestItem [id:" + m.GetID() + "]"
+}


### PR DESCRIPTION
Storage now has simple error that can be either a general error or a TupleList
Removed not implemented storage methods
Updated DeleteRequest to also hold the timelime
Created Inserted request
SImplified Timeline and ProducerID as strings (since they are not copied for each message now)
Simplified Coordinator listeners and gRPC code
Message has now 3 structs, each designed for its own purpose