### PR TITLE
Producer limit bytes (workaround)

### DIFF
--- a/broker/cmd/dejaqcli-producer/README.md
+++ b/broker/cmd/dejaqcli-producer/README.md
@@ -47,7 +47,8 @@ type Config struct {
 	ConstantBurstsTickEventsCount int    `env:"CONSTANT_TICK_COUNT"`
 
 	// the number of events to be sent in a single GRPC call
-	BatchSize int `env:"BATCH_SIZE" env-default:"3000"`
+	BatchMaxCount  int `env:"BATCH_MAX_COUNT" env-default:"3000"`
+	BatchBytesSize int `env:"BATCH_MAX_BYTES" env-default:"1024"`
 	// the size of the messages
 	BodySizeBytes int `env:"BODY_SIZE" env-default:"12000"`
 	// The event timestamp will be determined with a Time.Now() + Rand(-MinDelta,MaxDelta)

--- a/broker/cmd/dejaqcli-producer/main.go
+++ b/broker/cmd/dejaqcli-producer/main.go
@@ -40,8 +40,9 @@ type Config struct {
 	ConstantBurstsTickEventsCount int    `env:"CONSTANT_TICK_COUNT"`
 
 	// the max number of events to be sent in a single GRPC call
-	BatchMaxCount  int `env:"BATCH_MAX_COUNT" env-default:"3000"`
-	BatchBytesSize int `env:"BATCH_MAX_BYTES" env-default:"1024"`
+	BatchMaxCount int `env:"BATCH_MAX_COUNT" env-default:"3000"`
+	//half of a Mb
+	BatchBytesSize int `env:"BATCH_MAX_BYTES" env-default:"62500"`
 	// the size of the messages
 	BodySizeBytes int `env:"BODY_SIZE" env-default:"12000"`
 	// The event timestamp will be determined with a Time.Now() + Rand(-MinDelta,MaxDelta)

--- a/broker/cmd/dejaqcli/main.go
+++ b/broker/cmd/dejaqcli/main.go
@@ -344,10 +344,10 @@ func runProducers(ctx context.Context, client brokerClient.Client, logger logrus
 			pc := sync_produce.SyncProduceConfig{
 				Strategy:               sync_produce.StrategySingleBurst,
 				SingleBurstEventsCount: toProduce,
-				BatchSize:              config.batchSize,
+				BatchMaxCount:          config.batchSize,
 				EventTimelineMinDelta:  config.produceDeltaMin,
 				EventTimelineMaxDelta:  config.produceDeltaMax,
-				BodySizeBytes:          12 * 1024,
+				BodySizeBytes:          14 * 1024,
 				DeterministicEventID:   true,
 			}
 

--- a/broker/cmd/docker-compose/docker-compose.yml
+++ b/broker/cmd/docker-compose/docker-compose.yml
@@ -18,8 +18,9 @@ services:
       TIMEOUT: ''
       CONSTANT_TICK_DURATION: '1s'
       CONSTANT_TICK_COUNT: 1000
-      BATCH_SIZE: 1000
-      BODY_SIZE: 12000
+      BATCH_MAX_COUNT: 1000
+      #1024 for 1kb messages
+      BODY_SIZE: 2048
 
   consumer1:
     image: dejaq/testsyncconsumer:latest

--- a/broker/cmd/docker-compose/plus-2c-15kmsgs.yml
+++ b/broker/cmd/docker-compose/plus-2c-15kmsgs.yml
@@ -4,12 +4,13 @@ version: "3"
 services:
   producer1:
     environment:
+      CONSTANT_TICK_DURATION: 1s
       CONSTANT_TICK_COUNT: 15000
-      BATCH_SIZE: 2500
+      BATCH_SIZE: 5000
 
   consumer1:
     environment:
-      MAX_BUFFER_SIZE: 2500
+      MAX_BUFFER_SIZE: 5000
 
   consumer2:
     image: dejaq/testsyncconsumer:latest
@@ -21,7 +22,7 @@ services:
       TOPIC: 'compose1'
       TIMEOUT: ''
       CONSUMER_ID: 'c1-consumer2'
-      MAX_BUFFER_SIZE: 2500
+      MAX_BUFFER_SIZE: 5000
 
   consumer3:
     image: dejaq/testsyncconsumer:latest
@@ -33,4 +34,4 @@ services:
       TOPIC: 'compose1'
       TIMEOUT: ''
       CONSUMER_ID: 'c1-consumer3'
-      MAX_BUFFER_SIZE: 2500
+      MAX_BUFFER_SIZE: 5000

--- a/client/go.mod
+++ b/client/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/flatbuffers v1.11.0
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/pkg/errors v0.8.0
+	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/common v0.6.0
 	github.com/sirupsen/logrus v1.2.0
 	go.uber.org/atomic v1.5.1

--- a/client/go.sum
+++ b/client/go.sum
@@ -6,6 +6,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZq
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -36,6 +37,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mihaioprea/go-metrics-prometheus v0.0.0-20190927062427-83c6e4a84584/go.mod h1:+lSIxPVc767NSVjCVGc/OYsapjtbXsa2+2AC6rFzTyE=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -49,14 +51,17 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
+github.com/prometheus/client_golang v1.1.0 h1:BQ53HtBmfOitExawJ6LokA4x8ov/z0SYYb0+HxJfRI8=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0 h1:kRhiuYSXR3+uv2IbVbZhUxK5zVD/2pp3Gd2PpvPkpEo=
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.3 h1:CTwfnzjQ+8dS6MhHHu4YswVAD99sL2wjPqP+VkURmKE=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=

--- a/client/timeline/sync_consume/sync_consume.go
+++ b/client/timeline/sync_consume/sync_consume.go
@@ -112,10 +112,10 @@ func Consume(ctx context.Context, logger logrus.FieldLogger, c *consumer.Consume
 	}
 
 	//if we are finished and some events are still in batch
-	if err != nil && config.DeleteMessages {
-		deleted, deleteEerr := deleteBatcher.flush(ctx)
-		if deleteEerr != nil {
-			logger.WithError(deleteEerr).Error("delete failed")
+	if err == nil && config.DeleteMessages {
+		deleted, err = deleteBatcher.flush(ctx)
+		if err != nil {
+			logger.WithError(err).Error("delete failed")
 		}
 		r.Deleted += deleted
 		if config.DeleteMessages {

--- a/client/timeline/sync_consume/sync_consume.go
+++ b/client/timeline/sync_consume/sync_consume.go
@@ -93,7 +93,7 @@ func Consume(ctx context.Context, logger logrus.FieldLogger, c *consumer.Consume
 			}
 		}
 
-		if r.PartialInfoReceived%100000 == 0 {
+		if r.PartialInfoReceived%10000 == 0 {
 			logger.Infof("consumed messages: %d avg latency: %s removed: %d", r.Received, avg.Get().String(), r.Deleted)
 			r.PartialInfoReceived = 0
 		}


### PR DESCRIPTION
Implement batch flush of producer by max size in bytes
Fix false positive errors at delete consumer
Workaround/temporary fix to limit the msg size to 14kb
Alter default composer to work with 2kb messages, more realistic